### PR TITLE
Fix #52: Refactored countfiles function in kevin_barrios_authorsFileTouches.py

### DIFF
--- a/repo_mining/kevin_barrios_authorsFileTouches.py
+++ b/repo_mining/kevin_barrios_authorsFileTouches.py
@@ -98,6 +98,7 @@ def countfiles(dictfiles, lsttokens, repo):
     except:
         print("Error receiving data, skipping")
         exit(0)
+     
 # GitHub repo
 repo = 'scottyab/rootbeer'
 # repo = 'Skyscanner/backpack' # This repo is commit heavy. It takes long to finish executing


### PR DESCRIPTION
The length of the countfiles was too long along with some duplication issues. To fix this, I used ChatGPT to help with duplication and also split countfiles into multiple functions, including some helper functions.
ChatGPT: [https://chatgpt.com/c/6703ba8d-b0cc-800b-8a49-0c994dc9d800](https://chatgpt.com/c/6703ba8d-b0cc-800b-8a49-0c994dc9d800)